### PR TITLE
Fix bug when movies are compared based on title

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,14 @@ async function init() {
                 return movie[prop]
         }
 
-        for (const movie of Array.from(movies.values()).sort((a, b) => value(a, sort_by) - value(b, sort_by))) {
+        for (const movie of Array.from(movies.values()).sort((a, b) => {
+                const valueA = value(a, sort_by); 
+                const valueB = value(b, sort_by);
+                if ( typeof valueA === "string" ){
+                    return valueA > valueB ? 1 : valueA < valueB ? -1 : 0;
+                }
+                return valueA - valueB;
+            })) {
             const li = /** @type {HTMLTemplateElement} */ (document.querySelector("template#movie-item")).content.firstElementChild.cloneNode(true);
             li.querySelector("span").innerText = movie.title;
             li.querySelector("img").src = `https://image.tmdb.org/t/p/w200${movie.poster_path}`;


### PR DESCRIPTION
The sorting algorithm (a - b) does not work with String values. It produces NaN.

This PR fixes the bug so that movies are correctly sorted by title value along with ID and release_dates.

**BEFORE:**

![Velvette Before](https://github.com/user-attachments/assets/3a68011d-49b1-46bc-99e9-70b8034212e9)

**AFTER THE FIX:**

![Velvette After](https://github.com/user-attachments/assets/d8f551e0-2dfe-4439-b720-c5bd9f5f8ab6)
